### PR TITLE
[task] Take user defined language code for html tag

### DIFF
--- a/Plugin/PageConfigPlugin.php
+++ b/Plugin/PageConfigPlugin.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Staempfli\Seo\Plugin;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\View\Page\Config as Subject;
+
+class PageConfigPlugin
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    public function __construct(
+        ScopeConfigInterface $scopeConfig
+    ) {
+        $this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * @param Subject $subject
+     * @param string $elementType
+     * @return string[]
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function beforeGetElementAttributes(Subject $subject, $elementType)
+    {
+        if ($elementType != Subject::ELEMENT_TYPE_HTML) {
+            return [$elementType];
+        }
+        $subject->setElementAttribute(
+            Subject::ELEMENT_TYPE_HTML,
+            Subject::HTML_ATTRIBUTE_LANG,
+            str_replace('_', '-', $this->getLocaleCode())
+        );
+        return [$elementType];
+    }
+
+    /**
+     * @return string
+     */
+    private function getLocaleCode()
+    {
+        $localeCode = $this->scopeConfig->getValue('seo/hreflang/locale_code', 'stores')
+            ?: $this->scopeConfig->getValue('general/locale/code', 'stores');
+        return str_replace('_', '-', strtolower($localeCode));
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2018 Stämpfli AG. All rights reserved.
+ * @author avs@integer-net.de
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="Magento\Framework\View\Page\Config">
+        <plugin name="staempfli_seo" type="Staempfli\Seo\Plugin\PageConfigPlugin" />
+    </type>
+</config>


### PR DESCRIPTION
It's the same configuration field as for href lang. If it's not filled for
the current store, the locale code is taken instead.

Context:
```
<!doctype html>
<html lang="fr">
    <head >
```
where `fr` is the individually filled language code.