### PR TITLE
Expose hreflang only for active stores

### DIFF
--- a/Block/HrefLang.php
+++ b/Block/HrefLang.php
@@ -37,6 +37,10 @@ class HrefLang extends Template
     {
         $data = [];
         foreach ($this->getStores() as $store) {
+            if ($store->isActive() == false) {
+                continue;
+            }
+            
             $url = $this->getStoreUrl($store);
             if ($url) {
                 $data[$this->getLocaleCode($store)] = $url;


### PR DESCRIPTION
At the moment the hreflang attribute is written for every store present in the shop.
As an inactive store can not be accessed, check if a store is active before adding the corresponding hreflang.